### PR TITLE
Add wrapper `say` function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
-pub extern crate ferris_says;
+use std::io::Result as IoResult;
+
+extern crate ferris_says;
+
+pub fn say<W>(input: &[u8], width: usize, writer: &mut W) -> IoResult<()>
+    where W: std::io::Write {
+    ferris_says::say(input, width, writer)
+}
 
 #[macro_export]
 macro_rules! ferrisprint {
@@ -8,7 +15,7 @@ macro_rules! ferrisprint {
             let stdout = stdout();
             let width = 24;
             let mut writer = BufWriter::new(stdout.lock());
-            $crate::ferris_says::say(concat!($fmt).as_bytes(), width, &mut writer).unwrap();
+            $crate::say(concat!($fmt).as_bytes(), width, &mut writer).unwrap();
         }
     };
 ($fmt:expr, $($arg:tt)*) => {
@@ -17,7 +24,7 @@ macro_rules! ferrisprint {
             let stdout = stdout();
             let width = 24;
             let mut writer = BufWriter::new(stdout.lock());
-            $crate::ferris_says::say(format!(concat!($fmt), $($arg)*).as_bytes(), width, &mut writer).unwrap();
+            $crate::say(format!(concat!($fmt), $($arg)*).as_bytes(), width, &mut writer).unwrap();
         }
     };
 }


### PR DESCRIPTION
This obviates the need for `pub extern crate`, preventing exporting the underlying crate and allowing for future changes (though this is somewhat unlikely in this case).

Inspired by reading [the relevant blog post](https://medium.com/@kimond/how-to-use-external-crates-with-our-macros-in-rust-6dfe025351e0) and wondering whether there wasn't a better way (and this may not be better — see: [Occam's Razor](https://en.wikipedia.org/wiki/Occam's_razor)).